### PR TITLE
Fix compile error when using glibc in openwrt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(Libev REQUIRED)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/buffer ${CMAKE_CURRENT_BINARY_DIR} ${LIBEV_INCLUDE_DIR})
 
-set(EXTRA_LIBS ${LIBEV_LIBRARY} dl)
+set(EXTRA_LIBS ${LIBEV_LIBRARY} dl m)
 set(SOURCE_FILES uhttpd.c log.c connection.c buffer/buffer.c http_parser.c ssl.c)
 
 set(UHTTPD_SSL_SUPPORT_CONFIG 1)


### PR DESCRIPTION
[ 66%] Built target uhttpd
make[6]: Entering directory '/home/xxx/openwrt-compile/openwrt/build_dir/target-x86_64_glibc/libuhttpd-nossl/libuhttpd-2.0.3'
make[6]: Leaving directory '/home/xxx/openwrt-compile/openwrt/build_dir/target-x86_64_glibc/libuhttpd-nossl/libuhttpd-2.0.3'
make[6]: Entering directory '/home/xxx/openwrt-compile/openwrt/build_dir/target-x86_64_glibc/libuhttpd-nossl/libuhttpd-2.0.3'
[ 75%] Linking C executable helloworld
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `sinh'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `ceil'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `atan2'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `tanh'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `atanh'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `cosh'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `fmod'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `acosh'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `acos'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `sin'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `atan'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `asin'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `exp'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `tan'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `cos'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `log'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `pow'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `log10'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `sqrt'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `asinh'
/home/xxx/openwrt-compile/openwrt/staging_dir/target-x86_64_glibc/usr/lib/liblua.so: undefined reference to `floor'