### PR TITLE
file: define _FILE_OFFSET_BITS to 64

### DIFF
--- a/src/file.c
+++ b/src/file.c
@@ -24,6 +24,7 @@
 
 #define _DEFAULT_SOURCE
 #define _XOPEN_SOURCE
+#define _FILE_OFFSET_BITS 64
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixes compilation under uClibc-ng where ino_t and off_t are the wrong types for the format string.