### PR TITLE
src/uhttpd.c: fix build without dlopen

### DIFF
--- a/src/uhttpd.c
+++ b/src/uhttpd.c
@@ -42,7 +42,9 @@ void conn_free(struct uh_connection *conn);
 static void uh_server_free(struct uh_server *srv)
 {
     struct uh_connection *conn = srv->conns;
+#ifdef HAVE_DLOPEN
     struct uh_plugin *p = srv->plugins;
+#endif
 
     ev_io_stop(srv->loop, &srv->ior);
 


### PR DESCRIPTION
Build without dlopen fails on:

```
/data/buildroot-test/instance-0/output-1/build/libuhttpd-3.4.0/src/uhttpd.c:45:23: error: unused variable 'p' [-Werror=unused-variable]
     struct uh_plugin *p = srv->plugins;
                       ^
```

Fixes:
 - http://autobuild.buildroot.org/results/b2bbd0681705b94e6b531996b39f62e47f089c92

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>