### PR TITLE
src/uhttpd.c: fix build without dlopen

### DIFF
--- a/src/uhttpd.c
+++ b/src/uhttpd.c
@@ -152,8 +152,8 @@ static int uh_server_ssl_init(struct uh_server *srv, const char *cert, const cha
 
 static int uh_load_plugin(struct uh_server *srv, const char *path)
 {
-    struct uh_server_internal *srvi = (struct uh_server_internal *)srv;
 #ifdef HAVE_DLOPEN
+    struct uh_server_internal *srvi = (struct uh_server_internal *)srv;
     struct uh_plugin_handler *h;
     struct uh_plugin *p;
     void *dlh;


### PR DESCRIPTION
Fix the following build failure without dlopen:

```
/home/buildroot/autobuild/instance-3/output-1/build/libuhttpd-3.8.0/src/uhttpd.c: In function 'uh_load_plugin':
/home/buildroot/autobuild/instance-3/output-1/build/libuhttpd-3.8.0/src/uhttpd.c:155:32: error: unused variable 'srvi' [-Werror=unused-variable]
     struct uh_server_internal *srvi = (struct uh_server_internal *)srv;
                                ^~~~
```

Fixes:
 - http://autobuild.buildroot.org/results/00e5b5e1da782dcedda48777cbb0a2cba9c98cec

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>