### PR TITLE
CMakeLists.txt: remove -Werror from CFLAGS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(CheckLibraryExists)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules/")
 
 add_definitions(-D_GNU_SOURCE -D_FILE_OFFSET_BITS=64)
-add_compile_options(-O -Wall -Werror --std=gnu99)
+add_compile_options(-O -Wall --std=gnu99)
 
 option(BUILD_STATIC "Build static library" OFF)
 


### PR DESCRIPTION
Build is broken with OpenSSL 3.0, see buildroot autobuilder logs: http://autobuild.buildroot.net/results/c09/c09c77e399e9ee410995a91a22306897eca667d1/build-end.log

/home/autobuild/autobuild/instance-2/output-1/build/libuhttpd-3.14.1/src/ssl/openssl.c:
 In function 'ssl_last_error_string':
/home/autobuild/autobuild/instance-2/output-1/build/libuhttpd-3.14.1/src/ssl/openssl.c:143:9:
 error: 'ERR_peek_error_line_data' is deprecated: Since OpenSSL 3.0 [-Werror=deprecated-declarations]

cc1: all warnings being treated as errors